### PR TITLE
リリースノートを自動作成

### DIFF
--- a/.github/workflows/release_merged.yml
+++ b/.github/workflows/release_merged.yml
@@ -93,5 +93,6 @@ jobs:
         with:
           tag: ${{ env.TAG_NAME }}
           draft: true
+          generateReleaseNotes: true
           artifacts: "*.zip"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .*
+!.gitignore
+!.github/
 nsuite-kmscli

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.*
 nsuite-kmscli


### PR DESCRIPTION
GitHub Actions でリリースの Draft を作る時にリリースノートも作成するようにします。
リリースの編集画面で「Generate release notes」のボタンを押すだけですが、できるだけ自動化したいので忘れないうちに次のリリースの時に入るように追加しておきます。

