### PR TITLE
Add `show-address` command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,7 @@ $ nsuite-kmscli new
 
 $ nsuite-kmscli add-tags 01234567-abcd-1234-9876-02468ace79bf tag1:value1 tag2:value2
 # tags added to key
+
+$ nsuite-kmscli show-address 01234567-abcd-1234-9876-02468ace79bf
+# show address of key (normally address is the same as alias)
 ```


### PR DESCRIPTION
The README.md file has been updated to include instructions on how to use the `show-address` command within the nsuite-kmscli tool. This additional command allows users to visualize the address of a key, which is typically the same as the alias of the key.