### PR TITLE
Downgrade artifact upload and download actions

### DIFF
--- a/.github/workflows/release_merged.yml
+++ b/.github/workflows/release_merged.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         run: go build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: nsuite-kmscli-${{ runner.os }}
           path: nsuite-kmscli*
@@ -78,7 +78,7 @@ jobs:
           git tag $TAG_NAME
           git push origin $TAG_NAME
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v2
       - name: Archive
         run: |
           ls -la *


### PR DESCRIPTION
The actions used for uploading and downloading artifacts in the release_merged.yml workflow have been downgraded. The upload action was changed from version 4 to version 3 and the download action from version 4 to version 2.