### PR TITLE
Update package compression from tar.gz to zip in GitHub workflow

### DIFF
--- a/.github/workflows/release_merged.yml
+++ b/.github/workflows/release_merged.yml
@@ -98,5 +98,5 @@ jobs:
           tag: ${{ env.TAG_NAME }}
           draft: true
           generateReleaseNotes: true
-          artifacts: "*.tar.gz"
+          artifacts: "*.zip"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The GitHub workflow's package archive process has been changed. Instead of generating artifacts in tar.gz format, we now use zip format. This change, applicable to the artifact creation and management in the release_merged.yml file, improves compatibility, especially with systems that do not support tar.gz format.