### PR TITLE
Switch artifact packaging from zip to tar.gz

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -43,11 +43,11 @@ jobs:
           ls -la *
           for dir in nsuite-kmscli-*
           do
-            target=$(basename $dir).zip
+            target=$(basename $dir).tar.gz
             echo "making $target"
             pushd $dir
             chmod +x *
-            zip ../$target *
+            tar czf ../$target *
             popd
           done
           ls -la *

--- a/.github/workflows/release_merged.yml
+++ b/.github/workflows/release_merged.yml
@@ -84,11 +84,11 @@ jobs:
           ls -la *
           for dir in nsuite-kmscli-*
           do
-            target=$(basename $dir).zip
+            target=$(basename $dir).tar.gz
             echo "making $target"
             pushd $dir
             chmod +x *
-            zip ../$target *
+            tar czf ../$target *
             popd
           done
           ls -la *
@@ -98,5 +98,5 @@ jobs:
           tag: ${{ env.TAG_NAME }}
           draft: true
           generateReleaseNotes: true
-          artifacts: "*.zip"
+          artifacts: "*.tar.gz"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changed the packaging format of the GitHub workflow artifacts from zip to tar.gz. This change is reflected in both the packaging and release generation scripts. Packaging with tar.gz may provide better compression efficiency than zip.